### PR TITLE
Use linux-c52x-node instead of linux-cpu-node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     stage("Lint Check") {
       agent { 
         docker {
-          label "linux-cpu-node"
+          label "linux-c52x-node"
           image "dgllib/dgl-ci-lint" 
         }
       }
@@ -38,7 +38,7 @@ pipeline {
         stage("Knowledge Graph CPU") {
           agent { 
             docker {
-              label "linux-cpu-node"
+              label "linux-c52x-node"
               image "dgllib/dgl-ci-cpu:conda" 
             }
           }


### PR DESCRIPTION
*Issue #, if available:*
Deprecate linux-cpu-node to avoid running job on the jenkins master node.


*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
