### PR TITLE
Add QuatE (quaternion knowledge graph embedding)

### DIFF
--- a/python/dglke/eval.py
+++ b/python/dglke/eval.py
@@ -45,7 +45,7 @@ class ArgParser(argparse.ArgumentParser):
         self.add_argument('--model_name', default='TransE',
                           choices=['TransE', 'TransE_l1', 'TransE_l2', 'TransR',
                                    'RESCAL', 'DistMult', 'ComplEx', 'RotatE',
-                                   'SimplE'],
+                                   'SimplE', 'QuatE'],
                           help='The models provided by DGL-KE.')
         self.add_argument('--data_path', type=str, default='data',
                           help='The path of the directory where DGL-KE loads knowledge graph data.')

--- a/python/dglke/kvserver.py
+++ b/python/dglke/kvserver.py
@@ -64,7 +64,7 @@ class ArgParser(argparse.ArgumentParser):
 
         self.add_argument('--model_name', default='TransE',
                           choices=['TransE', 'TransE_l1', 'TransE_l2', 'TransR',
-                                   'RESCAL', 'DistMult', 'ComplEx', 'RotatE'],
+                                   'RESCAL', 'DistMult', 'ComplEx', 'RotatE', 'QuatE'],
                           help='model to use')
         self.add_argument('--data_path', type=str, default='../data',
                           help='root path of all dataset')

--- a/python/dglke/models/__init__.py
+++ b/python/dglke/models/__init__.py
@@ -18,4 +18,4 @@
 #
 
 from .general_models import KEModel, InferModel
-from .ke_model import TransEModel, TransE_l2Model, TransE_l1Model, DistMultModel, TransRModel, ComplExModel, RESCALModel, RotatEModel, GNNModel
+from .ke_model import TransEModel, TransE_l2Model, TransE_l1Model, DistMultModel, TransRModel, ComplExModel, RESCALModel, RotatEModel, GNNModel, QuatEModel

--- a/python/dglke/models/general_models.py
+++ b/python/dglke/models/general_models.py
@@ -25,6 +25,7 @@ Graph Embedding Model
 5. ComplEx
 6. RotatE
 7. SimplE
+8. QuatE
 """
 import os
 import numpy as np
@@ -94,6 +95,8 @@ class InferModel(object):
             self.score_func = RotatEScore(gamma, emb_init)
         elif model_name == 'SimplE':
             self.score_func = SimplEScore()
+        elif model_name == 'QuatE':
+            self.score_func = QuatEScore()
 
     def load_emb(self, path, dataset):
         """Load the model.
@@ -189,7 +192,7 @@ class KEModel(object):
         Global configs.
     model_name : str
         Which KG model to use, including 'TransE_l1', 'TransE_l2', 'TransR',
-        'RESCAL', 'DistMult', 'ComplEx', 'RotatE', 'SimplE'
+        'RESCAL', 'DistMult', 'ComplEx', 'RotatE', 'SimplE', 'QuatE'
     n_entities : int
         Num of entities.
     n_relations : int
@@ -263,6 +266,8 @@ class KEModel(object):
             self.score_func = RotatEScore(gamma, self.emb_init)
         elif model_name == 'SimplE':
             self.score_func = SimplEScore()
+        elif model_name == 'QuatE':
+            self.score_func = QuatEScore()
 
         self.model_name = model_name
         self.head_neg_score = self.score_func.create_neg(True)

--- a/python/dglke/models/ke_model.py
+++ b/python/dglke/models/ke_model.py
@@ -25,6 +25,7 @@ Knowledge Graph Embedding Model
 5. DistMult
 6. ComplEx
 7. RotatE
+8. QuatE
 """
 import os
 from abc import abstractmethod, ABCMeta
@@ -976,3 +977,11 @@ class GNNModel(BasicGEModel):
         relation_emb_file = 'relation.npy'
         self._entity_emb.load(model_path, entity_emb_file)
         self._relation_emb.load(model_path, relation_emb_file)
+
+class QuatEModel(KGEModel):
+    """ QuatE Model
+    """
+    def __init__(self, device):
+        model_name = 'QuatE'
+        score_func = QuatEScore()
+        super(QuatEModel, self).__init__(device, model_name, score_func)

--- a/python/dglke/models/pytorch/score_fun.py
+++ b/python/dglke/models/pytorch/score_fun.py
@@ -639,3 +639,107 @@ class SimplEScore(nn.Module):
                 score = th.clamp(tmp, -20, 20)
                 return score
             return fn
+
+class QuatEScore(nn.Module):
+    """QuatE score function
+    Paper link: https://papers.nips.cc/paper/2019/hash/d961e9f236177d65d21100592edb0769-Abstract.html
+    """
+    def __init__(self):
+        super(QuatEScore, self).__init__()
+
+    def edge_func(self, edges):
+        head_r, head_i, head_j, head_k = th.chunk(edges.src['emb'], 4, dim=-1)
+        rel_r, rel_i, rel_j, rel_k = th.chunk(edges.data['emb'], 4, dim=-1)
+        tail_r, tail_i, tail_j, tail_k = th.chunk(edges.dst['emb'], 4, dim=-1)
+
+        rel_norm = th.stack((rel_r, rel_i, rel_j, rel_k), dim=0).norm(p=2, dim=0)
+
+        x_r = (head_r * rel_r - head_i * rel_i - head_j * rel_j - head_k * rel_k) / (rel_norm + 1e-15)
+        x_i = (head_r * rel_i + head_i * rel_r + head_j * rel_k - head_k * rel_j) / (rel_norm + 1e-15)
+        x_j = (head_r * rel_j - head_i * rel_k + head_j * rel_r + head_k * rel_i) / (rel_norm + 1e-15)
+        x_k = (head_r * rel_k + head_i * rel_j - head_j * rel_i + head_k * rel_r) / (rel_norm + 1e-15)
+
+        score = x_r * tail_r + x_i * tail_i + x_j * tail_j + x_k * tail_k
+        return {'score': th.sum(score, dim=-1)}
+
+    def infer(self, head_emb, rel_emb, tail_emb):
+        hidden_dim = head_emb.shape[1]
+        head_r, head_i, head_j, head_k = th.chunk(head_emb.reshape(head_emb.shape[0], 1, 1, hidden_dim), 4, dim=-1)
+        rel_r, rel_i, rel_j, rel_k = th.chunk(rel_emb.reshape(1, rel_emb.shape[0], 1, hidden_dim), 4, dim=-1)
+        tail_r, tail_i, tail_j, tail_k = th.chunk(tail_emb.reshape(1, 1, tail_emb.shape[0], hidden_dim), 4, dim=-1)
+
+        rel_norm = th.stack((rel_r, rel_i, rel_j, rel_k), dim=0).norm(p=2, dim=0)
+
+        x_r = (head_r * rel_r - head_i * rel_i - head_j * rel_j - head_k * rel_k) / (rel_norm + 1e-15)
+        x_i = (head_r * rel_i + head_i * rel_r + head_j * rel_k - head_k * rel_j) / (rel_norm + 1e-15)
+        x_j = (head_r * rel_j - head_i * rel_k + head_j * rel_r + head_k * rel_i) / (rel_norm + 1e-15)
+        x_k = (head_r * rel_k + head_i * rel_j - head_j * rel_i + head_k * rel_r) / (rel_norm + 1e-15)
+
+        score = x_r * tail_r + x_i * tail_i + x_j * tail_j + x_k * tail_k
+        return th.sum(score, dim=-1)
+
+    def prepare(self, g, gpu_id, trace=False):
+        pass
+
+    def create_neg_prepare(self, neg_head):
+        def fn(rel_id, num_chunks, head, tail, gpu_id, trace=False):
+            return head, tail
+
+        return fn
+
+    def update(self, gpu_id=-1):
+        pass
+
+    def reset_parameters(self):
+        pass
+
+    def save(self, path, name):
+        pass
+
+    def load(self, path, name):
+        pass
+
+    def forward(self, g):
+        g.apply_edges(lambda edges: self.edge_func(edges))
+
+    def create_neg(self, neg_head):
+        if neg_head:
+            def fn(heads, relations, tails, num_chunks, chunk_size, neg_sample_size):
+                hidden_dim = heads.shape[1]
+                emb_r, emb_i, emb_j, emb_k = th.chunk(tails, 4, dim=-1)
+                rel_r, rel_i, rel_j, rel_k = th.chunk(relations, 4, dim=-1)
+
+                rel_norm = th.stack((rel_r, rel_i, rel_j, rel_k), dim=0).norm(p=2, dim=0)
+                rel_i, rel_j, rel_k = -rel_i, -rel_j, -rel_k
+
+                x_r = (emb_r * rel_r - emb_i * rel_i - emb_j * rel_j - emb_k * rel_k) / (rel_norm + 1e-15)
+                x_i = (emb_r * rel_i + emb_i * rel_r + emb_j * rel_k - emb_k * rel_j) / (rel_norm + 1e-15)
+                x_j = (emb_r * rel_j - emb_i * rel_k + emb_j * rel_r + emb_k * rel_i) / (rel_norm + 1e-15)
+                x_k = (emb_r * rel_k + emb_i * rel_j - emb_j * rel_i + emb_k * rel_r) / (rel_norm + 1e-15)
+
+                emb_quaternion = th.cat((x_r, x_i, x_j, x_k), dim=-1)
+                tmp = emb_quaternion.reshape(num_chunks, chunk_size, hidden_dim)
+                heads = heads.reshape(num_chunks, neg_sample_size, hidden_dim)
+                heads = th.transpose(heads, 1, 2)
+                return th.bmm(tmp, heads)
+
+            return fn
+        else:
+            def fn(heads, relations, tails, num_chunks, chunk_size, neg_sample_size):
+                hidden_dim = heads.shape[1]
+                emb_r, emb_i, emb_j, emb_k = th.chunk(heads, 4, dim=-1)
+                rel_r, rel_i, rel_j, rel_k = th.chunk(relations, 4, dim=-1)
+
+                rel_norm = th.stack((rel_r, rel_i, rel_j, rel_k), dim=0).norm(p=2, dim=0)
+
+                x_r = (emb_r * rel_r - emb_i * rel_i - emb_j * rel_j - emb_k * rel_k) / (rel_norm + 1e-15)
+                x_i = (emb_r * rel_i + emb_i * rel_r + emb_j * rel_k - emb_k * rel_j) / (rel_norm + 1e-15)
+                x_j = (emb_r * rel_j - emb_i * rel_k + emb_j * rel_r + emb_k * rel_i) / (rel_norm + 1e-15)
+                x_k = (emb_r * rel_k + emb_i * rel_j - emb_j * rel_i + emb_k * rel_r) / (rel_norm + 1e-15)
+
+                emb_quaternion = th.cat((x_r, x_i, x_j, x_k), dim=-1)
+                tmp = emb_quaternion.reshape(num_chunks, chunk_size, hidden_dim)
+                tails = tails.reshape(num_chunks, neg_sample_size, hidden_dim)
+                tails = th.transpose(tails, 1, 2)
+                return th.bmm(tmp, tails)
+            return fn

--- a/python/dglke/tests/test_infer.py
+++ b/python/dglke/tests/test_infer.py
@@ -92,7 +92,8 @@ ke_infer_funcs = {'TransE': TransEScore,
                   'RESCAL': RESCALScore,
                   'TransR': TransRScore,
                   'RotatE': RotatEScore,
-                  'SimplE': SimplEScore}
+                  'SimplE': SimplEScore,
+                  'QuatE': QuatEScore}
 
 class FakeEdge:
     def __init__(self, hemb, temb, remb):
@@ -267,6 +268,9 @@ def test_score_func_rotate():
 def test_score_func_simple():
     check_infer_score('SimplE')
 
+def test_score_func_quate():
+    check_infer_score('QuatE')
+
 if __name__ == '__main__':
     test_score_func_transe()
     test_score_func_distmult()
@@ -274,3 +278,4 @@ if __name__ == '__main__':
     test_score_func_rescal()
     test_score_func_rotate()
     test_score_func_simple()
+    test_score_func_quate()

--- a/python/dglke/tests/test_score.py
+++ b/python/dglke/tests/test_score.py
@@ -52,12 +52,13 @@ def generate_rand_graph(n, func_name):
     arr = (sp.sparse.random(n, n, density=0.1, format='coo') != 0).astype(np.int64)
     g = dgl.DGLGraph(arr, readonly=True)
     num_rels = 10
-    entity_emb = F.uniform((g.number_of_nodes(), 10), F.float32, F.cpu(), 0, 1)
+    dim = 16
+    entity_emb = F.uniform((g.number_of_nodes(), dim), F.float32, F.cpu(), 0, 1)
     if func_name == 'RotatE':
-        entity_emb = F.uniform((g.number_of_nodes(), 20), F.float32, F.cpu(), 0, 1)
-    rel_emb = F.uniform((num_rels, 10), F.float32, F.cpu(), -1, 1)
+        entity_emb = F.uniform((g.number_of_nodes(), 2 * dim), F.float32, F.cpu(), 0, 1)
+    rel_emb = F.uniform((num_rels, dim), F.float32, F.cpu(), -1, 1)
     if func_name == 'RESCAL':
-        rel_emb = F.uniform((num_rels, 10*10), F.float32, F.cpu(), 0, 1)
+        rel_emb = F.uniform((num_rels, dim * dim), F.float32, F.cpu(), 0, 1)
     g.ndata['id'] = F.arange(0, g.number_of_nodes())
     rel_ids = np.random.randint(0, num_rels, g.number_of_edges(), dtype=np.int64)
     g.edata['id'] = F.tensor(rel_ids, F.int64)
@@ -65,8 +66,8 @@ def generate_rand_graph(n, func_name):
     if (func_name == 'TransR'):
         args = {'gpu':-1, 'lr':0.1}
         args = dotdict(args)
-        projection_emb = ExternalEmbedding(args, 10, 10 * 10, F.cpu())
-        return g, entity_emb, rel_emb, (12.0, projection_emb, 10, 10)
+        projection_emb = ExternalEmbedding(args, dim, dim * dim, F.cpu())
+        return g, entity_emb, rel_emb, (12.0, projection_emb, dim, dim)
     elif (func_name == 'TransE'):
         return g, entity_emb, rel_emb, (12.0)
     elif (func_name == 'TransE_l1'):
@@ -74,7 +75,7 @@ def generate_rand_graph(n, func_name):
     elif (func_name == 'TransE_l2'):
         return g, entity_emb, rel_emb, (12.0, 'l2')
     elif (func_name == 'RESCAL'):
-        return g, entity_emb, rel_emb, (10, 10)
+        return g, entity_emb, rel_emb, (dim, dim)
     elif (func_name == 'RotatE'):
         return g, entity_emb, rel_emb, (12.0, 1.0)
     elif (func_name == 'SimplE'):

--- a/python/dglke/tests/test_score.py
+++ b/python/dglke/tests/test_score.py
@@ -79,6 +79,8 @@ def generate_rand_graph(n, func_name):
         return g, entity_emb, rel_emb, (12.0, 1.0)
     elif (func_name == 'SimplE'):
         return g, entity_emb, rel_emb, None
+    elif (func_name == 'QuatE'):
+        return g, entity_emb, rel_emb, None
     else:
         return g, entity_emb, rel_emb, None
 
@@ -90,7 +92,8 @@ ke_score_funcs = {'TransE': TransEScore,
                   'RESCAL': RESCALScore,
                   'TransR': TransRScore,
                   'RotatE': RotatEScore,
-                  'SimplE': SimplEScore}
+                  'SimplE': SimplEScore,
+                  'QuatE': QuatEScore}
 
 class BaseKEModel:
     def __init__(self, score_func, entity_emb, rel_emb):
@@ -204,6 +207,9 @@ def test_score_func_rotate():
 def test_score_func_simple():
     check_score_func('SimplE')
 
+def test_score_func_quate():
+    check_score_func('QuatE')
+
 if __name__ == '__main__':
     test_score_func_transe()
     test_score_func_distmult()
@@ -212,3 +218,4 @@ if __name__ == '__main__':
     test_score_func_transr()
     test_score_func_rotate()
     test_score_func_simple()
+    test_score_func_quate()

--- a/python/dglke/tests/test_topk.py
+++ b/python/dglke/tests/test_topk.py
@@ -30,7 +30,7 @@ import dgl
 from models import InferModel
 from models.infer import ScoreInfer, EmbSimInfer
 from models import TransEModel, TransE_l2Model, TransE_l1Model, TransRModel, RotatEModel
-from models import DistMultModel, ComplExModel, RESCALModel
+from models import DistMultModel, ComplExModel, RESCALModel, QuatEModel
 from models import GNNModel
 
 backend = os.environ.get('DGLBACKEND', 'pytorch')
@@ -109,7 +109,8 @@ def create_score_infer(model_name, entity_emb, rel_emb):
         model_name =='TransE_l1' or \
         model_name == 'TransE_l2' or \
         model_name == 'DistMult' or \
-        model_name == 'ComplEx':
+        model_name == 'ComplEx' or \
+        model_name == 'QuatE':
         model = InferModel('cpu', model_name, hidden_dim, batch_size=16)
     elif model_name == 'RESCAL':
         model = InferModel('cpu', model_name, hidden_dim)
@@ -380,6 +381,9 @@ def test_topk_rescal():
 
 def test_topk_rotate():
     check_topk_score('RotatE')
+
+def test_topk_quate():
+    check_topk_score('QuatE')
 
 def create_kge_emb_sim(emb, sfunc):
     sim_infer = EmbSimInfer(-1, None, sfunc, 32)
@@ -1012,6 +1016,12 @@ def test_rotate_model_topk(device='cpu'):
     check_topk_score2(model, exclude_mode='mask')
     check_topk_score2(model, exclude_mode='exclude')
 
+def test_quate_model_topk(device='cpu'):
+    model = QuatEModel(device)
+    check_topk_score2(model, exclude_mode=None)
+    check_topk_score2(model, exclude_mode='mask')
+    check_topk_score2(model, exclude_mode='exclude')
+
 def test_gnn_model_topk(device='cpu'):
     gamma = 12.0
     model = GNNModel(device, 'TransE', gamma)
@@ -1208,6 +1218,10 @@ def test_rotate_model_topk_emb(device='cpu'):
     model = RotatEModel(device, gamma)
     test_extended_jaccard_topk_emb2(model)
 
+def test_quate_model_topk_emb(device='cpu'):
+    model = QuatEModel(device)
+    test_l2_topk_emb2(model)
+
 def test_gnn_model_topk_emb(device='cpu'):
     gamma = 12.0
     model = GNNModel(device, 'TransE', gamma)
@@ -1253,6 +1267,7 @@ if __name__ == '__main__':
     test_rescal_model_topk(device=0)
     #test_transr_model_topk()
     test_rotate_model_topk(device=0)
+    test_quate_model_topk(device=0)
     test_gnn_model_topk(device=0)
 
     test_transe_model_topk_emb(device=0)
@@ -1261,4 +1276,5 @@ if __name__ == '__main__':
     test_rescal_model_topk_emb(device=0)
     #test_transr_model_topk_emb()
     test_rotate_model_topk_emb(device=0)
+    test_quate_model_topk_emb(device=0)
     test_gnn_model_topk_emb(device=0)

--- a/python/dglke/utils.py
+++ b/python/dglke/utils.py
@@ -203,7 +203,7 @@ class CommonArgParser(argparse.ArgumentParser):
         self.add_argument('--model_name', default='TransE',
                           choices=['TransE', 'TransE_l1', 'TransE_l2', 'TransR',
                                    'RESCAL', 'DistMult', 'ComplEx', 'RotatE',
-                                   'SimplE'],
+                                   'SimplE', 'QuatE'],
                           help='The models provided by DGL-KE.')
         self.add_argument('--data_path', type=str, default='data',
                           help='The path of the directory where DGL-KE loads knowledge graph data.')


### PR DESCRIPTION
*Description of changes:*

- Implement [QuatE (NeurIPS 2019)](https://papers.nips.cc/paper/2019/file/d961e9f236177d65d21100592edb0769-Paper.pdf)
- Change the embedding dimension in `test_score`, since the embedding dimension of QuatE shoud be divided by 4


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
