### PR TITLE
Update ScoreInfer to load model using the new config

### DIFF
--- a/python/dglke/models/infer.py
+++ b/python/dglke/models/infer.py
@@ -84,8 +84,8 @@ class ScoreInfer(object):
         # for logsigmoid use original gamma to make the score closer to 0.
         gamma=config['gamma'] if self.sfunc == 'logsigmoid' else 0.0
         model = InferModel(device=self.device,
-                           model_name=config['model'],
-                           hidden_dim=config['emb_size'],
+                           model_name=config['model_name'],
+                           hidden_dim=config['hidden_dim'],
                            double_entity_emb=config['double_ent'],
                            double_relation_emb=config['double_rel'],
                            gamma=gamma)


### PR DESCRIPTION
*Description of changes:*
Running `dglke_predict` fails because of the updated model config. This change updates the ScoreInfer load_model method to use the correct config keys.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
