### PR TITLE
Add data_files argument in dglke_client cmd for the custom dataset

### DIFF
--- a/python/dglke/dist_train.py
+++ b/python/dglke/dist_train.py
@@ -156,6 +156,9 @@ MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 DGLBACKEND=pytorch dglke_client --model %s \
         cmd_str += ' --no_save_emb'
     if args.neg_adversarial_sampling == True:
         cmd_str += ' -adv'
+    if args.data_files:
+        data_files = ' '.join(args.data_files)
+        cmd_str += ' --data_files %s' % (data_files)
 
     file_path = os.path.join(args.path, SCRIPT_FILE)
     if os.path.exists(file_path):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* `args.data_files` need to be passed into `dist_train_test`'s `get_dataset`, which is invoked by dglke_client

https://github.com/awslabs/dgl-ke/blob/247ba99b4e288b3c43bacd2b00e4832b01c9a5c3/python/dglke/kvclient.py#L202

https://github.com/awslabs/dgl-ke/blob/247ba99b4e288b3c43bacd2b00e4832b01c9a5c3/python/dglke/train_pytorch.py#L285

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
