### PR TITLE
Update Install.rst to python=3.5

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -12,7 +12,7 @@ DGL-KE works with the following operating systems:
 - Ubuntu 16.04 or higher version
 - macOS x
 
-DGL-KE requires Python version 3.5 or later. Python 3.4 or earlier is not tested. Python 2 support is coming.
+DGL-KE requires Python version 3.5 (but *not* later due to changes in how division works). Python 3.4 or earlier is not tested. Python 2 support is coming.
 
 DGL-KE supports multiple tensor libraries as backends, e.g., PyTorch and MXNet. For requirements on backends and how to select one, see Working with different backends. As a demo, we install Pytorch using ``pip``::
 


### PR DESCRIPTION
The documentation says any python >= 3.5 is fine.  This is false. It must be python 3.5 because the behavior of division changed in python 3.6, and running dglke_predict results in Runtime Error, specifically
“RuntimeError: Integer division of tensors using div or / is no longer supported, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.”

P.S. I can upload a conda environment.yml if that would help.

= Using python 3.6 =

When running predict, division is a runtime error.

(dglke) ➜  dgl-ke DGLBACKEND=pytorch dglke_predict --model_path ckpts/TransE_l2_FB15k_0/ --format 'h_r_t' --data_files head.list rel.list tail.list --exec_mode all --score_func logsigmoid --topK 5
ckpts/TransE_l2_FB15k_0/config.json
{'dataset': 'FB15k', 'model': 'TransE_l2', 'emb_size': 400, 'max_train_step': 500, 'batch_size': 1000, 'neg_sample_size': 200, 'lr': 0.25, 'gamma': 19.9, 'double_ent': False, 'double_rel': False, 'neg_adversarial_sampling': True, 'adversarial_temperature': 1.0, 'regularization_coef': 1e-09, 'regularization_norm': 3, 'emap_file': 'entities.dict', 'rmap_file': 'relations.dict'}
Traceback (most recent call last):
  File "/opt/miniconda3/envs/dglke/bin/dglke_predict", line 8, in <module>
    sys.exit(main())
  File "/opt/miniconda3/envs/dglke/lib/python3.6/site-packages/dglke/infer_score.py", line 216, in main
    result = model.topK(head, rel, tail, args.exec_mode, args.topK)
  File "/opt/miniconda3/envs/dglke/lib/python3.6/site-packages/dglke/models/infer.py", line 148, in topK
    idx = idx / num_tail
RuntimeError: Integer division of tensors using div or / is no longer supported, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.

= Using python 3.5 =

When running predict, division generates a warning-- which you can ignore-- that the behavior of division is changing soon.

(dglke_py3_5) ➜  dglke DGLBACKEND=pytorch dglke_predict --model_path ckpts/TransE_l2_FB15k_0/ --format 'h_r_t' --data_files head.list rel.list tail.list --exec_mode all --score_func logsigmoid --topK 5
Using backend: pytorch
ckpts/TransE_l2_FB15k_0/config.json
{'gamma': 19.9, 'batch_size': 1000, 'max_train_step': 500, 'emap_file': 'entities.dict', 'neg_sample_size': 200, 'emb_size': 400, 'neg_adversarial_sampling': True, 'rmap_file': 'relations.dict', 'double_rel': False, 'dataset': 'FB15k', 'adversarial_temperature': 1.0, 'model': 'TransE_l2', 'double_ent': False, 'regularization_coef': 1e-09, 'lr': 0.25, 'regularization_norm': 3}
/Users/distiller/project/conda/conda-bld/pytorch_1591914879026/work/aten/src/ATen/native/BinaryOps.cpp:81: UserWarning: Integer division of tensors using div or / is deprecated, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.
Inference Done
The result is saved in result.tsv

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
