### PR TITLE
Add default value of has_edge_importance

### DIFF
--- a/python/dglke/kvclient.py
+++ b/python/dglke/kvclient.py
@@ -48,6 +48,10 @@ class ArgParser(CommonArgParser):
                           help='IP configuration file of kvstore')
         self.add_argument('--num_client', type=int, default=1,
                           help='Number of client on each machine.')
+        self.add_argument('--has_edge_importance', action='store_true',
+                          help='Allow providing edge importance score for each'\
+                          ' edge during training. The positive score will be '\
+                          'adjusted as pos_score = pos_score * edge_importance')
 
 def get_long_tail_partition(n_relations, n_machine):
     """Relation types has a long tail distribution for many dataset.

--- a/python/dglke/kvserver.py
+++ b/python/dglke/kvserver.py
@@ -95,6 +95,10 @@ class ArgParser(argparse.ArgumentParser):
                           help='IP configuration file of kvstore')
         self.add_argument('--total_client', type=int, default=1,
                           help='Total number of client worker nodes')
+        self.add_argument('--has_edge_importance', action='store_true',
+                          help='Allow providing edge importance score for each'\
+                          ' edge during training. The positive score will be '\
+                          'adjusted as pos_score = pos_score * edge_importance')
 
 def get_server_data(args, machine_id):
    """Get data from data_path/dataset/part_machine_id


### PR DESCRIPTION
There is an issue that will be raised in distributed training, like
```
Traceback (most recent call last):
  File "/usr/local/bin/dglke_server", line 33, in <module>
    sys.exit(load_entry_point('dglke==0.1.0.dev0', 'console_scripts', 'dglke_server')())
  File "/usr/local/lib/python3.6/site-packages/dglke-0.1.0.dev0-py3.6.egg/dglke/kvserver.py", line 178, in main
  File "/usr/local/lib/python3.6/site-packages/dglke-0.1.0.dev0-py3.6.egg/dglke/kvserver.py", line 159, in start_server
  File "/usr/local/lib/python3.6/site-packages/dglke-0.1.0.dev0-py3.6.egg/dglke/kvserver.py", line 120, in get_server_data
  File "/usr/local/lib/python3.6/site-packages/dglke-0.1.0.dev0-py3.6.egg/dglke/train_pytorch.py", line 100, in load_model
  File "/usr/local/lib/python3.6/site-packages/dglke-0.1.0.dev0-py3.6.egg/dglke/models/general_models.py", line 212, in __init__
AttributeError: 'Namespace' object has no attribute 'has_edge_importance'
```

Because the `has_edge_importance` argument is required for KEModel, `kvserver.py` and `kvclient.py` should have a default value of this, and then pass to the `KEModel` in dglke/models/general_models.py