### PR TITLE
updated dgl dependency

### DIFF
--- a/python/dglke/dataloader/sampler.py
+++ b/python/dglke/dataloader/sampler.py
@@ -335,7 +335,7 @@ def ConstructGraph(dataset, args):
     n_entities = dataset.n_entities
 
     coo = sp.sparse.coo_matrix((np.ones(len(src)), (src, dst)), shape=[n_entities, n_entities])
-    g = dgl.DGLGraph(coo, readonly=True, multigraph=True, sort_csr=True)
+    g = dgl._deprecate.graph.DGLGraph(coo, readonly=True, multigraph=True, sort_csr=True)
     g.edata['tid'] = F.tensor(etype_id, F.int64)
     if args.has_edge_importance:
         e_impts = F.tensor(dataset.train[3], F.float32)
@@ -418,7 +418,7 @@ class TrainDataset(object):
                            exclude_positive=exclude_positive,
                            return_false_neg=False)
 
-class ChunkNegEdgeSubgraph(dgl.DGLGraph):
+class ChunkNegEdgeSubgraph(dgl._deprecate.graph.DGLGraph):
     """Wrapper for negative graph
 
         Parameters

--- a/python/dglke/models/ke_model.py
+++ b/python/dglke/models/ke_model.py
@@ -84,7 +84,7 @@ class BasicGEModel(object):
         """
         self._etid_field = etid_field
         self._ntid_filed = ntid_filed
-        assert isinstance(g, dgl.DGLGraph)
+        assert isinstance(g, dgl._deprecate.graph.DGLGraph)
         self._g = g
 
     def load(self, model_path):

--- a/python/dglke/partition.py
+++ b/python/dglke/partition.py
@@ -111,7 +111,7 @@ def main():
     src, etype_id, dst = dataset.train
     coo = sp.sparse.coo_matrix((np.ones(len(src)), (src, dst)),
             shape=[dataset.n_entities, dataset.n_entities])
-    g = dgl.DGLGraph(coo, readonly=True, multigraph=True, sort_csr=True)
+    g = dgl._deprecate.graph.DGLGraph(coo, readonly=True, multigraph=True, sort_csr=True)
     g.edata['tid'] = F.tensor(etype_id, F.int64)
 
     print('partition graph...')

--- a/python/dglke/tests/test_score.py
+++ b/python/dglke/tests/test_score.py
@@ -50,7 +50,7 @@ class dotdict(dict):
 
 def generate_rand_graph(n, func_name):
     arr = (sp.sparse.random(n, n, density=0.1, format='coo') != 0).astype(np.int64)
-    g = dgl.DGLGraph(arr, readonly=True)
+    g = dgl._deprecate.graph.DGLGraph(arr, readonly=True)
     num_rels = 10
     entity_emb = F.uniform((g.number_of_nodes(), 10), F.float32, F.cpu(), 0, 1)
     if func_name == 'RotatE':

--- a/python/dglke/tests/test_topk.py
+++ b/python/dglke/tests/test_topk.py
@@ -562,7 +562,7 @@ def check_topk_score2(score_model, exclude_mode):
                     th.full((num_entity*2,), 2, dtype=th.long),
                     th.full((num_entity*2,), 3, dtype=th.long)],
                     dim=0)
-    g = dgl.graph((src, dst))
+    g = dgl._deprecate.graph.DGLGraph((src, dst))
     g.edata['tid'] = etype
 
     _check_topk_score2(score_model, g, num_entity, num_rels, exclude_mode)

--- a/tests/scripts/task_kg_test.sh
+++ b/tests/scripts/task_kg_test.sh
@@ -34,10 +34,10 @@ conda activate ${DGLBACKEND}-ci
 # test
 if [ "$2" == "cpu" ]; then
     pip3 uninstall dgl
-    pip3 install dgl==0.4.3post2
+    pip3 install dgl
 else
     pip3 uninstall dgl
-    pip3 install dgl-cu102==0.4.3post2
+    pip3 install dgl-cu102
 fi
 
 pushd $KG_DIR> /dev/null

--- a/tests/scripts/task_kg_test.sh
+++ b/tests/scripts/task_kg_test.sh
@@ -36,8 +36,8 @@ if [ "$2" == "cpu" ]; then
     pip3 uninstall dgl
     pip3 install dgl
 else
-    pip3 uninstall dgl
-    pip3 install dgl-cu102
+    pip3 uninstall dgl>=0.5.0,<=0.9.1
+    pip3 install dgl-cu102>=0.5.0,<=0.9.1
 fi
 
 pushd $KG_DIR> /dev/null

--- a/tests/scripts/task_kg_test.sh
+++ b/tests/scripts/task_kg_test.sh
@@ -34,9 +34,9 @@ conda activate ${DGLBACKEND}-ci
 # test
 if [ "$2" == "cpu" ]; then
     pip3 uninstall dgl
-    pip3 install dgl
+    pip3 install dgl>=0.5.0,<=0.9.1
 else
-    pip3 uninstall dgl>=0.5.0,<=0.9.1
+    pip3 uninstall dgl
     pip3 install dgl-cu102>=0.5.0,<=0.9.1
 fi
 


### PR DESCRIPTION
*Issue #, if available:*  https://github.com/awslabs/dgl-ke/issues/256

*Description of changes:*
- Update the Graph structure to leverage the (deprecated) `dgl._deprecate.graph.DGLGraph`. Effectively uses a deprecated class in a recent version of DGL instead of using a deprecated version of the DGL package.
- Updates dgl dependency from `==0.4.3post2` to `>~0.5, <~0.9`, allowing sharing a recent DGL package installation with other  applications, and allowing use of Python binaries for 3.9+

Integration tests have been updated and are running on my local environment.
I have re-ran training on FB15k to validate that the results are as expected, here are the output of the script:
>  TransE_l1_FB15k_0
> Test average MRR : 0.6469265924837936
> Test average MR : 47.05067630478577
> Test average HITS@1 : 0.5219143065125019
> Test average HITS@3 : 0.7437236545851602
> Test average HITS@10 : 0.8403954563152816
> 
>  TransE_l2_FB15k_0
> Test average MRR : 0.6384227261417044
> Test average MR : 39.936754075603936
> Test average HITS@1 : 0.5046384858898614
> Test average HITS@3 : 0.743528973608031
> Test average HITS@10 : 0.8484196983291293
> 
>  DistMult_FB15k_0
> Test average MRR : 0.6508987590985638
> Test average MR : 55.72816610519544
> Test average HITS@1 : 0.5342046012425725
> Test average HITS@3 : 0.7367828545309881
> Test average HITS@10 : 0.84824194613262
> 
> ComplEx_FB15k_0
> Test average MRR : 0.7075530292466494
> Test average MR : 60.922652401347534
> Test average HITS@1 : 0.6077686174264868
> Test average HITS@3 : 0.7832100353811515
> Test average HITS@10 : 0.8677015794552319

The full training logs are available on this [gist](https://gist.github.com/guillaume-be/f4f1d884b77cede9f2cdf445058c5cc6)